### PR TITLE
phylo/download_lat_longs: fail on HTTP errors

### DIFF
--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -30,6 +30,8 @@ rule download_lat_longs:
         "results/lat_longs.tsv",
     params:
         url="https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/lat_longs.tsv",
+    # Allow retries in case of network errors
+    retries: 5
     log:
         "logs/download_lat_longs.txt"
     benchmark:
@@ -38,7 +40,7 @@ rule download_lat_longs:
         r"""
         exec &> >(tee {log:q})
 
-        curl {params.url:q} | \
+        curl -fsSL {params.url:q} | \
         sed "s/North Rhine Westphalia/North Rhine-Westphalia/g" | \
         sed "s/Baden-Wuerttemberg/Baden-Wurttemberg/g" \
         > {output:q}


### PR DESCRIPTION
## Description of proposed changes

Prevent silent HTTP errors that cause errors later in the workflow. Added `retries` directive to automatically retry if there are network errors.

Prompted by unexpected error in scheduled CI workflow <https://github.com/nextstrain/nipah/actions/runs/28892220144/job/85707605840#step:10:948>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
